### PR TITLE
Add google providers

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -7,6 +7,8 @@
   "dns": "hashicorp/dns@~> 3.2",
   "external": "hashicorp/external@~> 2.1",
   "github": "integrations/github@~> 6.0",
+  "google": "hashicorp/google@~> 6.50.0",
+  "googlebeta": "hashicorp/google-beta@~> 6.50.0",
   "http": "hashicorp/http@~> 3.1",
   "kubernetes": "hashicorp/kubernetes@~> 2.0",
   "local": "hashicorp/local@~> 2.1",

--- a/sharded-stacks.json
+++ b/sharded-stacks.json
@@ -13,6 +13,8 @@
         "docker",
         "external",
         "github",
+        "google",
+        "googlebeta",
         "kubernetes",
         "local",
         "null",
@@ -25,10 +27,7 @@
       "backend": {
         "workspaceName": "prebuilt-providers-official-new"
       },
-      "providers": [
-        "dns",
-        "http"
-      ]
+      "providers": ["dns", "http"]
     },
     "repos-partners": {
       "backend": {


### PR DESCRIPTION
## Summary
- Add `google` (hashicorp/google@~> 6.0) and `googlebeta` (hashicorp/google-beta@~> 6.0) providers to `provider.json`
- Add both providers to the `repos` stack in `sharded-stacks.json`

This creates the following repositories in the cdktn-io org:
- `cdktn-provider-google` + `cdktn-provider-google-go`
- `cdktn-provider-googlebeta` + `cdktn-provider-googlebeta-go`

Rebased from #6 (original author: Matt Stone).

## Test plan
- [x] Terraform plan shows expected changes for google repos
- [x] After adopt + import, plan shows minimal drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)