### PR TITLE
feat: Kubernetes provider v3

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -17,7 +17,7 @@
   "hcp": "hcp@~> 0.45",
   "helm": "helm@~> 3.0",
   "http": "hashicorp/http@~> 3.1",
-  "kubernetes": "hashicorp/kubernetes@~> 2.0",
+  "kubernetes": "hashicorp/kubernetes@~> 3.0",
   "local": "hashicorp/local@~> 2.1",
   "newrelic": "newrelic/newrelic@~> 3.7",
   "null": "hashicorp/null@~> 3.0",


### PR DESCRIPTION
It has been out since Dec 3, 2025. So we are well overdue to upgrade.

See https://github.com/hashicorp/terraform-provider-kubernetes/blob/25d5269044e926cc9cd642e583c86a93b5fa86a2/CHANGELOG.md#300-dec-3-2025

I've generated bindings for v3 locally and had no issues.