### PR TITLE
fix: Use pull_request_target for Plan workflow

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,6 +1,6 @@
 name: "Plan"
 
-on: [pull_request]
+on: [pull_request_target]
 concurrency: ${{ github.workflow }}-${{ github.head_ref }}
 
 permissions:


### PR DESCRIPTION
This allows PRs from external users to be able to run checks successfully due to needing access to secrets. The main cdktn repo is setup this way (as are most other workflows in this one)