### PR TITLE
Drop dessant/lock-threads for a native github-script step

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -12,7 +12,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           issue-comment: >
             I'm going to lock this issue because it has been closed for at least 30 days. This helps our maintainers find and focus on the active issues.

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -12,13 +12,52 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
+      # Discussions aren't handled here: this repo has the Discussions feature
+      # disabled, and locking them requires the GraphQL API rather than REST.
+      - name: Lock closed issues and PRs after 30 days of inactivity
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          issue-comment: >
-            I'm going to lock this issue because it has been closed for at least 30 days. This helps our maintainers find and focus on the active issues.
-            If you've found a problem that seems similar to this, please [open a new issue](https://github.com/cdktn-io/cdktn-repository-manager/issues/new) so we can investigate further.
-          issue-inactive-days: 30
-          pr-comment: >
-            I'm going to lock this pull request because it has been closed for at least 30 days. This helps our maintainers find and focus on the active issues.
-            If you've found a problem that seems related to this change, please [open a new issue](https://github.com/cdktn-io/cdktn-repository-manager/issues/new) so we can investigate further.
-          pr-inactive-days: 30
+          script: |-
+            const INACTIVE_DAYS = 30;
+            const LOCK_REASON = "resolved";
+
+            const cutoff = new Date();
+            cutoff.setUTCDate(cutoff.getUTCDate() - INACTIVE_DAYS);
+            const cutoffDate = cutoff.toISOString().slice(0, 10);
+
+            const comments = {
+              issue:
+                "I'm going to lock this issue because it has been closed for at least 30 days. This helps our maintainers find and focus on the active issues. " +
+                "If you've found a problem that seems similar to this, please [open a new issue](https://github.com/cdktn-io/cdktn-repository-manager/issues/new) so we can investigate further.",
+              pr:
+                "I'm going to lock this pull request because it has been closed for at least 30 days. This helps our maintainers find and focus on the active issues. " +
+                "If you've found a problem that seems related to this change, please [open a new issue](https://github.com/cdktn-io/cdktn-repository-manager/issues/new) so we can investigate further.",
+            };
+
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            for (const kind of ["issue", "pr"]) {
+              const items = await github.paginate(github.rest.search.issuesAndPullRequests, {
+                q: `repo:${context.repo.owner}/${context.repo.repo} is:closed is:unlocked is:${kind} closed:<${cutoffDate}`,
+                per_page: 100,
+              });
+
+              core.info(`Found ${items.length} closed, unlocked ${kind}(s) closed before ${cutoffDate}`);
+
+              for (const item of items) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: item.number,
+                  body: comments[kind],
+                });
+                await github.rest.issues.lock({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: item.number,
+                  lock_reason: LOCK_REASON,
+                });
+                core.info(`Locked ${kind} #${item.number}`);
+                await sleep(250);
+              }
+            }


### PR DESCRIPTION
## Summary

- Every scheduled run of the `Lock closed issues and PRs after 30 days` workflow has been failing for the past month with `"github-token" length must be less than or equal to 100 characters long`. Root cause: the pinned `dessant/lock-threads@v5.0.1` build validates the `github-token` input against a hardcoded max length of 100 characters, and the default `github.token` (the Actions-issued `GITHUB_TOKEN`) now regularly exceeds that. Upstream fixed this in [dessant/lock-threads#55](https://github.com/dessant/lock-threads/issues/55) (released as `v6.0.2`, raising the limit to 1000).
- Rather than just bumping the pin, this replaces the third-party action entirely: locking closed, inactive issues/PRs is a handful of GitHub API calls, not something that needs an external dependency. The workflow now uses `actions/github-script` (already used elsewhere in this repo, same pinned SHA) with an inline script that:
  - Searches for closed, unlocked issues/PRs older than 30 days via the Search API.
  - Posts the same comment text as before.
  - Locks each with reason `resolved`.
- This needs no repo checkout (only talks to the GitHub API) and keeps the workflow free of inline bash.
- Discussion locking (enabled by `lock-threads` v5+'s default, but never actually applicable since this repo has GitHub Discussions disabled — confirmed via a 404 on `/discussions`) is intentionally not replicated, since discussion locking is only exposed via the GraphQL API, not REST.

## Test plan

- [ ] Confirm the next scheduled run (or a manual `workflow_dispatch`, if added) completes without the previous validation error.
- [ ] Spot-check that a closed, 30+ day old issue/PR gets the expected comment and lock reason (`resolved`) applied.
