### PR TITLE
feat: add awscc provider bindings

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -2,6 +2,7 @@
   "acme": "vancluever/acme@~> 2.10",
   "archive": "hashicorp/archive@~> 2.2",
   "aws": "hashicorp/aws@~> 6.0",
+  "awscc": "hashicorp/awscc@~> 1.0",
   "azuread": "hashicorp/azuread@~> 3.0",
   "azurerm": "azurerm@~> 5.0",
   "cfncompat": "cdktn-io/cfncompat@~> 0.1",

--- a/providersWithCustomRunners.json
+++ b/providersWithCustomRunners.json
@@ -1,5 +1,6 @@
 {
   "aws": {},
+  "awscc": {},
   "azurerm": {},
   "datadog": {},
   "google": {},

--- a/sharded-stacks.json
+++ b/sharded-stacks.json
@@ -40,6 +40,7 @@
         "workspaceName": "prebuilt-providers-official-new"
       },
       "providers": [
+        "awscc",
         "dns",
         "hcp",
         "http"


### PR DESCRIPTION
## Summary

Adds the [`hashicorp/awscc`](https://registry.terraform.io/providers/hashicorp/awscc/latest) provider so `cdktn-provider-awscc` / `cdktn-provider-awscc-go` get created and managed like the other prebuilt providers.

- `provider.json`: `"awscc": "hashicorp/awscc@~> 1.0"`
- `sharded-stacks.json`: added `awscc` to the `repos-official-new` shard (workspace `prebuilt-providers-official-new`), alongside the other officially-maintained HashiCorp providers added outside the primary shard (`dns`, `hcp`, `http`)
- `providersWithCustomRunners.json`: added `awscc`

`awscc` isn't in `original-providers.json` — there was never an archived `cdktf/cdktf-provider-awscc` repo to import, so this follows the "Adding a New Provider" flow from `CLAUDE.md` rather than the `import-provider.yml` flow. New `cdktn-provider-awscc(-go)` repos will be created by Terraform on deploy, not adopted.

## Why draft

`awscc`'s schema maps almost the entire CloudFormation resource surface and relies on deeply nested collection wrappers that cdktn's code generation doesn't support yet. Keeping this in draft until [open-constructs/cdk-terrain#300](https://github.com/open-constructs/cdk-terrain/pull/300) lands support for those nested collection wrappers — merging/deploying before then would produce repos whose `upgrade-repositories` codegen step fails.

## Custom runner

No existing custom-runner classification tool (`scripts/bench-providers-schema.py`) could be run here — `terraform` isn't available in this sandbox and outbound access to `registry.terraform.io` is blocked by the environment's network policy, so I couldn't pull `awscc`'s live schema to benchmark it. I added `awscc` to `providersWithCustomRunners.json` based on general knowledge that its schema is one of the largest of any Terraform provider (near-total 1:1 mapping of AWS CloudFormation resource types), well past the documented thresholds (`schema_json > 2.25MB` or `total_attrs > 6000`) for every other mega-provider in that list (`aws`, `azurerm`, `datadog`, `google`, `googlebeta`, `kubernetes`). **Please re-run/verify with `scripts/bench-providers-schema.py` before merging.**

## Validation done

- `provider.json` / `sharded-stacks.json` / `providersWithCustomRunners.json` are valid JSON
- `npx tsc --noEmit` passes
- `npx tsx main.ts` runs past `validateProviderNames` (the provider-name/key matching and `-go`-suffix checks) with no errors — the only failure is `terraform: not found`, since Terraform isn't installed in this sandbox
- Could not run `cdktf synth` / a real Terraform plan (no `terraform` binary, no registry network access, no GitHub credentials in this sandbox) — CI should validate this on push

## Next steps

- [ ] Land [open-constructs/cdk-terrain#300](https://github.com/open-constructs/cdk-terrain/pull/300) (deeply-nested collection wrapper support)
- [ ] Confirm `awscc` version constraint (`~> 1.0`) and custom-runner classification
- [ ] Mark ready for review and merge


---
_Generated by [Claude Code](https://claude.ai/code/session_013J67HJuFnNEDwK3qoGWa2W)_