### PR TITLE
feat!: adopt provider-project 0.8, Node 24, and PyPI Trusted Publishing for all providers

### DIFF
--- a/.github/workflows/import-provider.yml
+++ b/.github/workflows/import-provider.yml
@@ -231,7 +231,7 @@ jobs:
              - After apply succeeds, it will automatically dispatch the `migrate-provider` workflow
              - The migration creates a PR in the provider repo to switch to `@cdktn` scope
           4. **Merge** this PR after `/migrate` succeeds
-          5. **Trigger `force-release`** on the provider repo if the migration PR didn't auto-release
+          5. **Manually dispatch `release`** (with a `sha` and the `publish_to_*` toggles) on the provider repo if the migration PR didn't auto-release
           EOF
           )" \
             --head "import/${PROVIDER}" \

--- a/.github/workflows/migrate-provider.yml
+++ b/.github/workflows/migrate-provider.yml
@@ -49,9 +49,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          # Also runs `yarn add --dev @cdktn/provider-project@latest`, which needs
-          # node>=22.11.0 -- see the note in upgrade-repositories.yml.
-          node-version: "22"
+          # Also installs @cdktn/provider-project and synths a provider repo, so it
+          # must satisfy both engines floors -- see the note in upgrade-repositories.yml.
+          node-version: "24"
 
       - name: Setup Copywrite tool
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3

--- a/.github/workflows/migrate-provider.yml
+++ b/.github/workflows/migrate-provider.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: "20"
+          # Also runs `yarn add --dev @cdktn/provider-project@latest`, which needs
+          # node>=22.11.0 -- see the note in upgrade-repositories.yml.
+          node-version: "22"
 
       - name: Setup Copywrite tool
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3

--- a/.github/workflows/migrate-provider.yml
+++ b/.github/workflows/migrate-provider.yml
@@ -156,7 +156,7 @@ jobs:
                   '',
                   '### Next steps:',
                   `- Once the migration PR merges, merge this PR`,
-                  `- If needed, trigger \`force-release\` on \`cdktn-provider-${provider}\` for initial publish`,
+                  `- If needed, manually dispatch \`release\` (with a \`sha\` and the \`publish_to_*\` toggles) on \`cdktn-provider-${provider}\` for initial publish`,
                 ].join('\n')
               : `## ⚠️ Migration workflow ran for \`${provider}\` but no PR was created (it may already exist on \`auto/migrate-to-cdktn-scope\`).`;
 

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -75,14 +75,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          # @cdktn/provider-project declares engines node>=22.11.0 as of v0.8.0, and
-          # yarn classic *errors* on an engines mismatch (unlike npm, which warns):
-          #   error @cdktn/provider-project@0.8.1: The engine "node" is incompatible
-          #   with this module. Expected version ">= 22.11.0". Got "20.20.2"
-          # 22 is what provider-project itself is built and tested against. This only
-          # affects the tooling that runs projen here, not the minNodeVersion of the
-          # generated provider repos.
-          node-version: "22"
+          # yarn classic *errors* on an engines mismatch (unlike npm, which warns),
+          # so this must satisfy BOTH:
+          #   - @cdktn/provider-project, engines node>=22.11.0 as of v0.8.0
+          #   - the provider repo itself, engines node>=24.11.0 from the template's
+          #     minNodeVersion -- `yarn install --check-files` runs inside it
+          # Keep this >= projenrc.template.js's minNodeVersion.
+          node-version: "24"
 
       - name: Setup Copywrite tool
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -107,6 +107,15 @@ jobs:
         env:
           NODE_OPTIONS: "--max-old-space-size=7168"
 
+      - name: Remove workflows projen no longer generates
+        # @cdktn/provider-project v0.7.42 folded force-release.yml into
+        # release.yml so npm/PyPI OIDC have a single trusted-publisher
+        # entrypoint. projen stops *generating* the file but never deletes the
+        # copy already committed, so without this it lingers in every provider
+        # repo as a second, now-unmaintained publish entrypoint.
+        run: rm -f .github/workflows/force-release.yml
+        working-directory: ./provider
+
       - name: Add headers using Copywrite tool
         run: copywrite headers
         working-directory: ./provider

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -75,7 +75,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: "20"
+          # @cdktn/provider-project declares engines node>=22.11.0 as of v0.8.0, and
+          # yarn classic *errors* on an engines mismatch (unlike npm, which warns):
+          #   error @cdktn/provider-project@0.8.1: The engine "node" is incompatible
+          #   with this module. Expected version ">= 22.11.0". Got "20.20.2"
+          # 22 is what provider-project itself is built and tested against. This only
+          # affects the tooling that runs projen here, not the minNodeVersion of the
+          # generated provider repos.
+          node-version: "22"
 
       - name: Setup Copywrite tool
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3

--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -10,13 +10,7 @@ const project = new CdktnProviderProject({
   terraformProvider: "__PROVIDER__",
   cdktnVersion: "^0.23.0",
   constructsVersion: "^10.6.0",
-  // Node 20 went EOL 2026-04-30. This is also forced: @cdktn/provider-project
-  // declares engines node>=22.11.0 as of v0.8.0, and yarn classic *errors* on an
-  // engines mismatch, so provider repos cannot install ^0.8.0 on Node 20 at all.
-  // 24.11.0 is the first Node 24 LTS (supported to 2028-04-30); going to 22 would
-  // schedule another breaking engines bump before 2027-04-30.
-  // NOTE: projen derives @types/node@^24 from this automatically.
-  minNodeVersion: "24.11.0",
+  minNodeVersion: "24.11.0", // first Node 24 LTS; Node 20 went EOL 2026-04-30
   typescriptVersion: "~5.9.0", // JSII and TS should always use the same major/minor version range
   jsiiVersion: "~5.9.0", // JSII and TS should always use the same major/minor version range
   devDeps: ["@cdktn/provider-project@^0.8.0"],

--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -13,7 +13,7 @@ const project = new CdktnProviderProject({
   minNodeVersion: "20.16.0",
   typescriptVersion: "~5.9.0", // JSII and TS should always use the same major/minor version range
   jsiiVersion: "~5.9.0", // JSII and TS should always use the same major/minor version range
-  devDeps: ["@cdktn/provider-project@^0.7.0"],
+  devDeps: ["@cdktn/provider-project@^0.8.0"],
   isDeprecated: false,
   npmTrustedPublishing: true,
   pypiTrustedPublishing: __PYPI_TRUSTED__,

--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -10,7 +10,13 @@ const project = new CdktnProviderProject({
   terraformProvider: "__PROVIDER__",
   cdktnVersion: "^0.23.0",
   constructsVersion: "^10.6.0",
-  minNodeVersion: "20.16.0",
+  // Node 20 went EOL 2026-04-30. This is also forced: @cdktn/provider-project
+  // declares engines node>=22.11.0 as of v0.8.0, and yarn classic *errors* on an
+  // engines mismatch, so provider repos cannot install ^0.8.0 on Node 20 at all.
+  // 24.11.0 is the first Node 24 LTS (supported to 2028-04-30); going to 22 would
+  // schedule another breaking engines bump before 2027-04-30.
+  // NOTE: projen derives @types/node@^24 from this automatically.
+  minNodeVersion: "24.11.0",
   typescriptVersion: "~5.9.0", // JSII and TS should always use the same major/minor version range
   jsiiVersion: "~5.9.0", // JSII and TS should always use the same major/minor version range
   devDeps: ["@cdktn/provider-project@^0.8.0"],

--- a/providersWithPypiTrustedPublishing.json
+++ b/providersWithPypiTrustedPublishing.json
@@ -1,1 +1,1 @@
-["null", "kubernetes"]
+["*"]

--- a/providersWithPypiTrustedPublishing.json
+++ b/providersWithPypiTrustedPublishing.json
@@ -1,1 +1,1 @@
-["null"]
+["null", "kubernetes"]

--- a/scripts/force-release-providers.sh
+++ b/scripts/force-release-providers.sh
@@ -6,7 +6,7 @@
 if [[ $# -eq 0 ]] ; then
     echo 'Usage: scripts/force-release-providers.sh <filter>'
     echo
-    echo 'This script runs the workflow "force-release" on every provider listed in provider.json'
+    echo 'This script runs the manual dispatch of the "release" workflow on every provider listed in provider.json'
     echo 'Please note that the tool is quite naive and will generate a release for every provider you agree with'
     echo 'It DOES NOT see if the previous release is there or not, so please exercise caution while using it'
     echo
@@ -18,9 +18,11 @@ if [[ $# -eq 0 ]] ; then
 fi
 
 providers=$(jq -rcM "keys | .[]" provider.json)
-org="cdktf"
 filter=$1
-workflow_name=force-release
+# force-release.yml was folded into release.yml in @cdktn/provider-project v0.7.42
+# so npm/PyPI OIDC have a single trusted-publisher entrypoint. The manual inputs
+# (sha, publish_to_*) are unchanged, only the workflow file differs.
+workflow_name=release
 
 for provider in $providers; do
   read -p "Creating workflow for provider $provider. Continue? [y/n] " -n 1 -r


### PR DESCRIPTION
Completes the PyPI Trusted Publishing (OIDC) rollout and unblocks the fleet's dependency upgrades.

## What this does

1. **`@cdktn/provider-project` `^0.7.0` → `^0.8.0`.** The fleet is on 0.7.41 — the June 24 `upgrade-repositories` run predates the 0.7.42 publish by two days — so the force-release → `release.yml` consolidation has never reached any provider repo. `^0.8.0` also picks up v0.8.1, which unblocks projen 0.101 (`upgrade-main` has failed fleet-wide since 2026-06-29) and reverts a `release_pypi` runner regression.

2. **Node 24 (`minNodeVersion: 24.11.0`).** Forced, not optional: v0.8.0 declares `engines node>=22.11.0` and **yarn classic errors on an engines mismatch** (npm only warns), so provider repos cannot install `^0.8.0` on Node 20 at all. 24.11.0 is the first Node 24 LTS (supported to 2028-04-30); Node 20 went EOL 2026-04-30 and Node 22 EOLs 2027-04-30, which would schedule another breaking bump within a year. projen derives `@types/node@^24` automatically.

3. **PyPI Trusted Publishing for all providers** — allowlist flipped to `["*"]`, which also auto-enables future providers.

4. **`force-release.yml` deleted.** projen stopped generating it in v0.7.42 but never deletes the committed copy, so it would linger in all 29 repos as a second, unmaintained publish entrypoint. Tooling that dispatched it (`scripts/force-release-providers.sh`, plus instructions in `import-provider.yml` / `migrate-provider.yml`) now targets `release.yml`; the manual inputs are unchanged.

5. **Node 24 for the two workflows that synth a provider repo** (`upgrade-repositories.yml`, `migrate-provider.yml`). The binding constraint is the *template's* `minNodeVersion`, not provider-project's, because `yarn install --check-files` runs inside the generated repo. Keep these `>=` `projenrc.template.js`'s `minNodeVersion`.

## Canary evidence

Validated on both runner classes before flipping the allowlist:

| Provider | Version | `release_pypi` runner | Registries | Attestations |
|---|---|---|---|---|
| `null` | 14.0.0 | `ubuntu-latest` | all 5 ✅ | ✅ |
| `kubernetes` | 16.0.0 | `depot-ubuntu-24.04-8` (`depot-4j61h27wj7`) | all 5 ✅ | ✅ |

Every attestation is `predicateType: https://docs.pypi.org/attestations/publish/v1` with publisher `{kind: GitHub, repository: cdktn-io/cdktn-provider-<name>, workflow: release.yml}` — confirming trust resolves against the consolidated entrypoint. npm and PyPI are in lockstep for both.

The `kubernetes` canary closed the last open assumption: **PyPI mints OIDC tokens fine from a Depot self-hosted runner.** Unlike npm, PyPI binds trust to the workflow ref, not the runner environment, so `release_pypi` stays on the custom runner for the six providers that use one — which also keeps it matched to the 31GB `NODE_OPTIONS` heap ceiling `useCustomGithubRunner` writes into `.projen/tasks.json`.

## BREAKING CHANGE

Published provider packages move from `engines node>=20.16.0` to `>=24.11.0`. All 29 cut a **major** on their next release (as `null` 13.1.0→14.0.0 and `kubernetes` 15.1.1→16.0.0 already did). Those releases fire on each provider's own upgrade schedule, not at merge time.

## On merge

`deploy.yml` runs on push to `main` and calls `deploy-cdktf-stacks.yml` with `upgrade-repositories: true`, which invokes `upgrade-repositories.yml` via `workflow_call` with no `providers` input — so merging deliberately fans out to **all 29 providers** in one wave. That is the intent here; the canaries were run by dispatching `upgrade-repositories.yml` against this branch (`--ref feat/adopt-provider-project-0.8 -f providers=<name>`) precisely to avoid triggering it early.

TWINE secrets are left in place as a rollback path until every provider has published via OIDC at least once; their removal is tracked separately, as is the Slack webhook cleanup in #56.