### PR TITLE
feat!: run provider-repo tooling on pnpm

### DIFF
--- a/.github/workflows/deprecate-provider.yml
+++ b/.github/workflows/deprecate-provider.yml
@@ -35,17 +35,29 @@ jobs:
         with:
           repository: ${{ env.PROVIDER_REPO_FULL }}
           token: ${{ steps.app-token.outputs.token }}
+      # This job operates on a PROVIDER repo, so it needs pnpm and Node >= the
+      # template's minNodeVersion. Keep in sync with @cdktn/provider-project.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: "10.33.0"
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: "20"
+          # Provider repos declare engines node>=24.11.0; installing on Node 20 fails
+          # the engines check outright.
+          node-version: "24"
       - name: Install
-        run: yarn install
+        run: pnpm install --no-frozen-lockfile
       - name: Kick off the deprecation
         run: |
           sed -i "s/isDeprecated: false,/isDeprecated: true,/" .projenrc.js
       - name: Do a build
-        run: yarn && yarn build
+        run: |
+          # unset CI so projen's build doesn't spawn install:ci (--frozen-lockfile)
+          # after the sed above changes what projen will synthesize
+          unset CI
+          pnpm install --no-frozen-lockfile && pnpm run build
       - name: Reset the version in package.json
         run: npm pkg set version="0.0.0"
       - name: Create Pull Request

--- a/.github/workflows/migrate-provider.yml
+++ b/.github/workflows/migrate-provider.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Upgrade to latest @cdktn/provider-project
         run: |
           pnpm add -D @cdktn/provider-project@latest
+          # projen >=0.101.7 is required for the pnpm APIs the template uses --
+          # see the note in upgrade-repositories.yml.
+          pnpm add -D projen@^0.101.20
 
       - name: Regenerate with projen
         run: |

--- a/.github/workflows/migrate-provider.yml
+++ b/.github/workflows/migrate-provider.yml
@@ -46,6 +46,14 @@ jobs:
           terraform_version: 1.13.3
           terraform_wrapper: false
 
+      # Runs on depot-ubuntu-24.04-8, which tracks the GitHub runner image: yarn 1.x
+      # is preinstalled but pnpm is not. Must precede setup-node.
+      # Keep in sync with @cdktn/provider-project's pnpm version.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: "10.33.0"
+
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
@@ -57,7 +65,10 @@ jobs:
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3
 
       - name: Install dependencies
-        run: yarn install
+        # The repo being migrated is still yarn-based at this point, but projen will
+        # switch it to pnpm below and delete yarn.lock, so install with pnpm from the
+        # start rather than leaving a half-yarn/half-pnpm tree behind.
+        run: pnpm install --no-frozen-lockfile
 
       - name: Migrate to @cdktn scope
         run: |
@@ -77,14 +88,18 @@ jobs:
 
       - name: Upgrade to latest @cdktn/provider-project
         run: |
-          yarn add --dev @cdktn/provider-project@latest
+          pnpm add -D @cdktn/provider-project@latest
 
       - name: Regenerate with projen
         run: |
           unset CI
           npx projen
-          yarn install --check-files
-          yarn fetch
+          # `unset CI` is load-bearing under pnpm: CI=true implies --frozen-lockfile
+          # and the projen run above rewrites package.json.
+          pnpm install --no-frozen-lockfile
+          # `pnpm run fetch`, NOT `pnpm fetch` -- the latter is a pnpm builtin that
+          # fetches from the lockfile and generates nothing while exiting 0.
+          pnpm run fetch
           # Fix readme (requires src/version.json to be populated)
           npx projen
 
@@ -93,9 +108,11 @@ jobs:
 
       - name: Build and verify
         run: |
-          yarn build
+          # unset CI so projen's build doesn't spawn install:ci (--frozen-lockfile)
+          unset CI
+          pnpm run build
 
-        # yarn build bumps package.json, must reset after build!
+        # the build bumps package.json, must reset after build!
       - name: Reset the version in package.json
         run: npm pkg set version="0.0.0"
 

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -72,14 +72,25 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           path: provider
 
+      # The jsii-terraform container ships yarn 1.x baked in at /usr/bin/yarn but has
+      # no pnpm, so it must be installed. Must run BEFORE setup-node: setup-node's
+      # `cache: pnpm` (if ever enabled) needs pnpm already on PATH.
+      # The version is pinned rather than read from the provider repo's
+      # `packageManager` field, because on the yarn->pnpm transition run that field
+      # does not exist yet. Keep it in sync with @cdktn/provider-project's pnpm
+      # version (projen's DEFAULT_PNPM_VERSION).
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: "10.33.0"
+
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          # yarn classic *errors* on an engines mismatch (unlike npm, which warns),
-          # so this must satisfy BOTH:
+          # Package managers *error* on an engines mismatch, so this must satisfy BOTH:
           #   - @cdktn/provider-project, engines node>=22.11.0 as of v0.8.0
           #   - the provider repo itself, engines node>=24.11.0 from the template's
-          #     minNodeVersion -- `yarn install --check-files` runs inside it
+          #     minNodeVersion -- the install below runs inside it
           # Keep this >= projenrc.template.js's minNodeVersion.
           node-version: "24"
 
@@ -103,10 +114,16 @@ jobs:
           git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git checkout -b foo-bar-${{ github.run_number }}
-          yarn add --dev @cdktn/provider-project@latest
+          pnpm add -D @cdktn/provider-project@latest
           npx projen
-          yarn install --check-files
-          yarn fetch
+          # `unset CI` above matters under pnpm: CI=true implies --frozen-lockfile, and
+          # the `npx projen` on the line above rewrites package.json, so a frozen
+          # install would fail with ERR_PNPM_OUTDATED_LOCKFILE. Explicit here too.
+          pnpm install --no-frozen-lockfile
+          # MUST be `pnpm run fetch`, never `pnpm fetch`: the latter is a pnpm builtin
+          # that fetches from the lockfile, exits 0, and generates no bindings -- the
+          # workflow would then find no diff and report success having done nothing.
+          pnpm run fetch
           # fix the readme as it requires src/version.json to be populated
           npx projen
         working-directory: ./provider
@@ -129,7 +146,12 @@ jobs:
       - name: Check for changes
         id: git_diff
         run: |
-          git diff --exit-code || echo "has_changes=true" >> $GITHUB_OUTPUT
+          # Use git status, not `git diff`: diff only sees tracked modifications and
+          # deletions, so a run whose only effect is ADDING files goes undetected.
+          # The pnpm migration adds pnpm-lock.yaml and pnpm-workspace.yaml, and
+          # `git add .` in the commit step below would stage them regardless -- so
+          # detection has to agree with what actually gets committed.
+          [ -z "$(git status --porcelain)" ] || echo "has_changes=true" >> $GITHUB_OUTPUT
         working-directory: ./provider
 
       - if: steps.git_diff.outputs.has_changes

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -115,6 +115,16 @@ jobs:
           git config user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git checkout -b foo-bar-${{ github.run_number }}
           pnpm add -D @cdktn/provider-project@latest
+          # .projenrc.js runs under the PROVIDER REPO's own projen, not the template's.
+          # @cdktn/provider-project >=0.9.0 uses pnpm APIs that only exist in projen
+          # >=0.101.7 (pnpmOptions.workspaceYamlOptions,
+          # PnpmWorkspaceYamlSchemaNodeLinker), while the repos are still pinned to the
+          # projen that last synthed them (^0.99.74) -- so synth dies with
+          # "Cannot read properties of undefined (reading 'HOISTED')".
+          # pnpm won't resolve this via the peer range either, because the repo's own
+          # explicit devDependency wins. Bootstrap it; later synths pin the running
+          # version themselves.
+          pnpm add -D projen@^0.101.20
           npx projen
           # `unset CI` above matters under pnpm: CI=true implies --frozen-lockfile, and
           # the `npx projen` on the line above rewrites package.json, so a frozen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,11 @@ Example:
   - Builds matrix from `provider.json`
   - Checks out both this repo and each provider repo
   - Creates `.projenrc.js` from template
-  - Runs `yarn add --dev @cdktn/provider-project@latest` and `npx projen`
+  - Runs `pnpm add -D @cdktn/provider-project@latest` and `npx projen`
+  - Provider repos use **pnpm**; this repo's own build is still Yarn Classic. Only
+    the steps that run inside a checked-out provider repo use pnpm.
+  - Note `pnpm run fetch`, never `pnpm fetch` — the latter is a pnpm builtin that
+    fetches from the lockfile, exits 0, and regenerates nothing.
   - Detects breaking changes
   - Creates PRs with appropriate labels
 

--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -13,7 +13,7 @@ const project = new CdktnProviderProject({
   minNodeVersion: "24.11.0", // first Node 24 LTS; Node 20 went EOL 2026-04-30
   typescriptVersion: "~5.9.0", // JSII and TS should always use the same major/minor version range
   jsiiVersion: "~5.9.0", // JSII and TS should always use the same major/minor version range
-  devDeps: ["@cdktn/provider-project@^0.8.0"],
+  devDeps: ["@cdktn/provider-project@^0.9.0"],
   isDeprecated: false,
   npmTrustedPublishing: true,
   pypiTrustedPublishing: __PYPI_TRUSTED__,


### PR DESCRIPTION
Coordinated counterpart to [cdktn-provider-project#35](https://github.com/cdktn-io/cdktn-provider-project/pull/35), which switches generated provider repos from Yarn Classic to pnpm.

Only the steps that run **inside a checked-out provider repo** change. This repo's own build stays on Yarn Classic and can migrate independently — the `[SELF]` vs `[PROVIDER REPO]` split is clean.

| Workflow | Job | Changed |
|---|---|---|
| `upgrade-repositories.yml` | `upgrade-provider` | ✅ |
| `migrate-provider.yml` | `migrate` | ✅ |
| `deprecate-provider.yml` | `update_provider` | ✅ |
| `deprecate-provider.yml` | `update_self` | ❌ acts on this repo |
| everything else | — | ❌ acts on this repo |

## pnpm has to be installed — it isn't in the image

I ran the pinned container to check rather than assume:

```
terraconstructs/jsii-terraform@sha256:4942a4c6...
  node     v20.19.0   (overlaid to 24 by setup-node)
  yarn     /usr/bin/yarn -> 1.22.22   (apt, baked into jsii/superchain)
  corepack /usr/bin/corepack -> 0.31.0
  pnpm     command not found
```

yarn works today only because it's baked in; nothing installs it. `depot-ubuntu-24.04-8` and `ubuntu-latest` track the GitHub runner image — same story. Each job therefore gains a SHA-pinned `pnpm/action-setup`, placed **before** `setup-node` (its `cache: pnpm`, if ever enabled, needs pnpm on `PATH` first).

The version is pinned in the workflow rather than read from the provider repo's `packageManager` field, because on the yarn→pnpm transition run **that field doesn't exist yet**. Keep it in sync with the template's pnpm version.

## `pnpm fetch` would have silently regenerated nothing

`fetch` is a projen task — but `pnpm fetch` is *also* a **pnpm builtin** that installs from the lockfile only. It exits 0 and produces no provider bindings, so `git status` then finds no changes and the workflow **reports success having done nothing**, across all 29 repos. Every call site is `pnpm run fetch`, with an inline comment at each so it can't regress.

## `unset CI` became load-bearing

Under pnpm, `CI=true` implies `--frozen-lockfile`. Each of these steps runs `npx projen` (which rewrites `package.json`) immediately before installing, so a frozen install fails with `ERR_PNPM_OUTDATED_LOCKFILE`. Under yarn classic the existing `unset CI` was cosmetic. It's kept, made explicit with `--no-frozen-lockfile`, and added to the two build steps that previously ran with `CI` still set.

## Two pre-existing bugs fixed

**`deprecate-provider.yml`'s `update_provider` was already broken by #55.** It runs on `node-version: "20"`, but provider repos now declare `engines node>=24.11.0`, so its install fails the engines check regardless of pnpm. Now on 24.

**Change detection disagreed with what gets committed.** It used `git diff --exit-code`, which sees tracked modifications and deletions but **not added files** — while the commit step uses `git add .`. A run whose only effect was adding files would report no changes. Now `git status --porcelain`. This migration adds `pnpm-lock.yaml` and `pnpm-workspace.yaml`, so it would have been the first case to hit it.

## Note on `--check-files`

`yarn install --check-files` has no direct pnpm equivalent — pnpm verifies store integrity natively — so it becomes a plain install rather than `--force`.

---

> [!WARNING]
> **Draft. Do not merge before `@cdktn/provider-project` ships the pnpm template**, or `upgrade-repositories` will run pnpm against repos projen still generates for yarn.
>
> Merging also triggers the fleet fan-out (`deploy.yml` → `upgrade-repositories`, no `providers` filter), so this should be canaried the same way #55 was: dispatch `upgrade-repositories.yml` against this branch with `-f providers=<name>` first.