### PR TITLE
fix!: decouple published engines.node floor from CI Node (24.11.0 -> 22.11.0)

### DIFF
--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -88,10 +88,11 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           # Package managers *error* on an engines mismatch, so this must satisfy BOTH:
-          #   - @cdktn/provider-project, engines node>=22.11.0 as of v0.8.0
-          #   - the provider repo itself, engines node>=24.11.0 from the template's
+          #   - @cdktn/provider-project, engines node>=22.11.0
+          #   - the provider repo itself, engines node>=22.11.0 from the template's
           #     minNodeVersion -- the install below runs inside it
-          # Keep this >= projenrc.template.js's minNodeVersion.
+          # This is tooling, so it tracks projenrc.template.js's workflowNodeVersion
+          # (current LTS), NOT minNodeVersion (the consumer floor). Keep it >= the floor.
           node-version: "24"
 
       - name: Setup Copywrite tool

--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -10,13 +10,30 @@ const project = new CdktnProviderProject({
   terraformProvider: "__PROVIDER__",
   cdktnVersion: "^0.23.0",
   constructsVersion: "^10.6.0",
-  // engines.node -- the compat floor we publish to consumers. First Node 24 LTS;
-  // Node 20 went EOL 2026-04-30.
-  minNodeVersion: "24.11.0",
-  // CI runs current 24 LTS, not the floor. projen defaults workflowNodeVersion to
-  // minNodeVersion, which pinned every setup-node step to the oldest version we
-  // support -- backwards for CI, and 24.11.0 specifically has a reported memory
-  // leak (nodejs/node#60482) fixed in 24.12.
+  // engines.node -- the compat floor we publish to CONSUMERS, not a CI knob.
+  // projen's own docs: "Most projects should not use this option ... Setting this
+  // option has very high impact on the consumers of your package, as package
+  // managers will actively prevent usage with node versions you have marked as
+  // incompatible. To change the node version of your CI/CD workflows, use
+  // `workflowNodeVersion`."
+  //
+  // Policy: oldest MAINTAINED LTS line (the same rule that produced the previous
+  // 20.16.0 floor while Node 20 was in maintenance). Per nodejs/Release:
+  //   v20 EOL 2026-04-30 (dead)  v22 maintenance until 2027-04-30  v24 active LTS
+  // so 22.11.0 today. Also matches @cdktn/provider-project's own engines.
+  //
+  // Verified empirically on Node 22.22.3 against @cdktn/provider-null: cdktn App +
+  // NullProvider + Resource synthesizes correctly, so a 24 floor was simply untrue.
+  // jsii pins the emitted JS to ES2022 (Node 16.11+), so the artifact does not
+  // depend on the Node version CI builds it with.
+  minNodeVersion: "22.11.0",
+  // CI runs current 24 LTS. This is deliberately DECOUPLED from minNodeVersion:
+  // projen only falls back to minNodeVersion as a convenience default, and the
+  // build/package jobs are toolchain jobs -- they compile with jsii and package
+  // with pacmak, they never run the published bindings in a consumer app, so
+  // matching them to the floor validated nothing. Real floor coverage belongs in
+  // the end-to-end provider-repo test (cdktn-provider-project#20), pinned to
+  // minNodeVersion.
   workflowNodeVersion: "24.18.0",
   typescriptVersion: "~5.9.0", // JSII and TS should always use the same major/minor version range
   jsiiVersion: "~5.9.0", // JSII and TS should always use the same major/minor version range

--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -10,7 +10,14 @@ const project = new CdktnProviderProject({
   terraformProvider: "__PROVIDER__",
   cdktnVersion: "^0.23.0",
   constructsVersion: "^10.6.0",
-  minNodeVersion: "24.11.0", // first Node 24 LTS; Node 20 went EOL 2026-04-30
+  // engines.node -- the compat floor we publish to consumers. First Node 24 LTS;
+  // Node 20 went EOL 2026-04-30.
+  minNodeVersion: "24.11.0",
+  // CI runs current 24 LTS, not the floor. projen defaults workflowNodeVersion to
+  // minNodeVersion, which pinned every setup-node step to the oldest version we
+  // support -- backwards for CI, and 24.11.0 specifically has a reported memory
+  // leak (nodejs/node#60482) fixed in 24.12.
+  workflowNodeVersion: "24.18.0",
   typescriptVersion: "~5.9.0", // JSII and TS should always use the same major/minor version range
   jsiiVersion: "~5.9.0", // JSII and TS should always use the same major/minor version range
   devDeps: ["@cdktn/provider-project@^0.9.0"],


### PR DESCRIPTION
## Problem

Wave 2 set `minNodeVersion: "24.11.0"` to get our CI off EOL Node 20. projen turns `minNodeVersion` into **`engines.node` in every published provider package**, so a CI-motivated change silently became a consumer-facing constraint.

projen documents these as two different knobs (`node-package.d.ts:164-181`):

> "**Most projects should not use this option.** … Setting this option has **very high impact on the consumers of your package**, as package managers will actively prevent usage with node versions you have marked as incompatible. **To change the node version of your CI/CD workflows, use `workflowNodeVersion`.**"

## The floor was untrue

Tested on Node **22.22.3** against `@cdktn/provider-null@14.0.0` (published with `>= 24.11.0`):

| Package manager | Result |
|---|---|
| pnpm 11.17.0 | installs **silently**, no warning |
| npm 10.9.8 (default) | installs, `EBADENGINE` warning, exit 0 |
| npm + `engine-strict` | **hard fail** |
| yarn classic 1.22 | **hard fail**, exit 1, nothing installed |

And it runs fine — `cdktn` App + `NullProvider` + `Resource` → `SYNTH OK`, correct `cdk.tf.json`. jsii pins emitted JS to **ES2022** (Node 16.11+), so the artifact does not depend on the Node version CI builds it with.

## Blast radius

Only **2 of 29** providers reached npm with the 24 floor — `kubernetes@16.0.0` and `null@14.0.0`, the two Wave 2 canaries. The other 27 still publish `>= 20.16.0` and would have shipped it on their **next release**. Both published ones were major bumps, so semver shielded existing consumers.

## The fix

`minNodeVersion: "22.11.0"` — the same rule that produced the previous `20.16.0`: **oldest maintained LTS line**. Per `nodejs/Release`:

| Line | Status |
|---|---|
| v20 | EOL 2026-04-30 (dead) |
| **v22** | maintenance until **2027-04-30** |
| v24 | active LTS |

Also matches `@cdktn/provider-project`'s own `engines`.

`workflowNodeVersion: "24.18.0"` is unchanged, so **CI still runs current LTS**. The build/package jobs are toolchain jobs — they compile with jsii and package with pacmak, never running the published bindings in a consumer app — so pinning them to the floor validated nothing. Real floor coverage belongs in the end-to-end provider-repo test (provider-project#20), pinned to `minNodeVersion`.

## Known side effect

`provider-upgrade.yml` and `deprecate-packages.yml` pin `setup-node` to `project.minNodeVersion` (`provider-upgrade.ts:66`, `deprecate-packages.ts:61`), so **those two tooling workflows drop to 22.11.0** until provider-project is fixed to use `workflowNodeVersion` there. Both only install deps and run projen, and `>= 22.11.0` satisfies every tool in that chain. Follow-up tracked separately — same conflation, two more places.

## Rollout

Merging triggers `deploy.yml` → `upgrade-repositories` across all 29 providers, same as #57.