### PR TITLE
feat: allow a per-provider Node heap override

### DIFF
--- a/.github/lib/create-projen-files.js
+++ b/.github/lib/create-projen-files.js
@@ -9,11 +9,24 @@ module.exports = ({ providerName }) => {
   const mainFolder = path.join(process.env.GITHUB_WORKSPACE, "main");
   const provider = require(path.join(mainFolder, "provider.json"));
   const providerVersion = provider[providerName];
-  const providersWithCustomRunners = require(
+  // Maps a provider to its custom-runner settings, e.g.
+  //   { "datadog": { "nodeHeapSizeMb": 24576 }, "aws": {} }
+  // An empty object means "use the custom runner with default settings".
+  //
+  // This was historically a plain array of provider names. Accept that shape
+  // too, so an in-flight PR that appends a bare name still synths correctly
+  // instead of silently dropping every provider off the custom runner.
+  const customRunnerConfig = require(
     path.join(mainFolder, "providersWithCustomRunners.json"),
   );
-  const useCustomGithubRunner =
-    providersWithCustomRunners.includes(providerName);
+  const customRunners = Array.isArray(customRunnerConfig)
+    ? Object.fromEntries(customRunnerConfig.map((name) => [name, {}]))
+    : customRunnerConfig;
+  const runnerOptions = customRunners[providerName];
+  const useCustomGithubRunner = runnerOptions !== undefined;
+  // Leave unset to take the default for the runner class; the provider-project
+  // template decides what that is. Only override for a provider that still OOMs.
+  const nodeHeapSizeMb = runnerOptions?.nodeHeapSizeMb;
   // PyPI Trusted Publishing (OIDC) rollout allowlist. During the canary phase
   // this lists individual providers; set it to ["*"] to enable for all.
   const providersWithPypiTrustedPublishing = require(
@@ -29,6 +42,7 @@ module.exports = ({ providerName }) => {
   const projenrc = template
     .replace("__PROVIDER__", providerVersion)
     .replace("__CUSTOM_RUNNER__", useCustomGithubRunner)
+    .replace("__NODE_HEAP_MB__", nodeHeapSizeMb ?? "undefined")
     .replace("__PYPI_TRUSTED__", usePypiTrustedPublishing);
   fs.writeFileSync(
     path.join(process.env.GITHUB_WORKSPACE, "provider", ".projenrc.js"),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ The infrastructure is divided into **sharded stacks** defined in `sharded-stacks
 - **`main.ts`**: Entry point that creates CDKTF stacks and validates configuration
 - **`provider.json`**: Maps provider names to Terraform registry versions (e.g., `"aws": "hashicorp/aws@~> 6.0"`)
 - **`sharded-stacks.json`**: Defines which providers belong to which stack
-- **`providersWithCustomRunners.json`**: Lists providers requiring custom GitHub runners
+- **`providersWithCustomRunners.json`**: Maps providers requiring custom GitHub runners to their settings, e.g. `{"datadog": {"nodeHeapSizeMb": 24576}, "aws": {}}`. An empty object means "custom runner, default settings". A legacy plain-array form is still accepted.
 - **`projenrc.template.js`**: Template for `.projenrc.js` files generated in provider repositories
 - **`lib/repository.ts`**: Defines `GithubRepository` and `GithubRepositoryFromExistingRepository` constructs
 - **`lib/secrets.ts`**: Manages GitHub Actions secrets for package publishing
@@ -148,7 +148,7 @@ yarn upgrade:next
    "providers": ["archive", "aws", "newprovider"]
    ```
 
-3. If the provider needs custom runners, add to `providersWithCustomRunners.json`
+3. If the provider needs custom runners, add it to `providersWithCustomRunners.json` with an empty object: `"newprovider": {}`. Only add `nodeHeapSizeMb` if the provider has demonstrably OOMed on the default ceiling.
 
 4. Validate and deploy:
    ```bash
@@ -202,7 +202,8 @@ Located in `.github/lib/`:
 
 - **`create-projen-files.js`**: Generates `.projenrc.js` for provider repos using the template
   - Replaces `__PROVIDER__` with version from `provider.json`
-  - Replaces `__CUSTOM_RUNNER__` with boolean from `providersWithCustomRunners.json`
+  - Replaces `__CUSTOM_RUNNER__` with a boolean derived from `providersWithCustomRunners.json` (provider present = true)
+  - Replaces `__NODE_HEAP_MB__` with that provider's `nodeHeapSizeMb`, or `undefined` to take the runner-class default
 
 - **`collect-changes.js`**: Detects breaking vs non-breaking changes in provider updates
 - **`create-pr.js`**: Creates pull requests for provider upgrades

--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -7,6 +7,10 @@ const { CdktnProviderProject } = require("@cdktn/provider-project");
 
 const project = new CdktnProviderProject({
   useCustomGithubRunner: __CUSTOM_RUNNER__,
+  // Per-provider V8 heap ceiling from providersWithCustomRunners.json.
+  // `undefined` means "take the default for the runner class" -- which is what
+  // every provider should use unless it has demonstrably OOMed on the default.
+  nodeHeapSizeMb: __NODE_HEAP_MB__,
   terraformProvider: "__PROVIDER__",
   cdktnVersion: "^0.23.0",
   constructsVersion: "^10.6.0",

--- a/providersWithCustomRunners.json
+++ b/providersWithCustomRunners.json
@@ -1,8 +1,8 @@
-[
-  "aws",
-  "azurerm",
-  "datadog",
-  "google",
-  "googlebeta",
-  "kubernetes"
-]
+{
+  "aws": {},
+  "azurerm": {},
+  "datadog": {},
+  "google": {},
+  "googlebeta": {},
+  "kubernetes": {}
+}


### PR DESCRIPTION
Pairs with cdktn-provider-project#38, which lowers the custom-runner heap default 31744MB → 28672MB and adds the `nodeHeapSizeMb` option. **merged ✅**

## Change

`providersWithCustomRunners.json` becomes a map from provider to its custom-runner settings:

```json
{ "aws": {}, "datadog": { "nodeHeapSizeMb": 24576 } }
```

An empty object means "custom runner, default settings" — which is what **all six providers get for now**. Datadog deliberately runs against the new 28672MB default first, so we find out whether the default alone fixes it before reaching for a per-provider value.

## Backward compatibility

`create-projen-files.js` still accepts the historical plain-array form. Without that, an in-flight PR appending a bare provider name would parse as a map with no matching keys and silently drop **every** provider off the custom runner — a quiet, fleet-wide regression.

Verified end-to-end against all four shapes; each generates a `.projenrc.js` that passes `node --check`:

| Config | `useCustomGithubRunner` | `nodeHeapSizeMb` |
|---|---|---|
| map, no override | `true` | `undefined` |
| map, with override | `true` | `24576` |
| **legacy array** | `true` | `undefined` |
| provider absent | `false` | `undefined` |

`deprecate-provider.yml`'s `sed -i '/"$PROVIDER"/d'` still matches, since the map key line contains the quoted provider name.

## Validation caveat

datadog's `package-go` is **~50% flaky**, so a single green run after rollout does not confirm the fix — the same trap that made the 2026-07-27 green run look like a pnpm fix. Several consecutive greens are needed.