### PR TITLE
fix: Bypass provider-project minimum age requirement when explicitly …

### DIFF
--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -115,7 +115,7 @@ jobs:
           git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git checkout -b foo-bar-${{ github.run_number }}
-          pnpm add -D @cdktn/provider-project@latest
+          pnpm add -D @cdktn/provider-project@latest --config.minimumReleaseAge=0
           # .projenrc.js runs under the PROVIDER REPO's own projen, not the template's.
           # @cdktn/provider-project >=0.9.0 uses pnpm APIs that only exist in projen
           # >=0.101.7 (pnpmOptions.workspaceYamlOptions,


### PR DESCRIPTION
…upgrading.

This workflow is ran manually when we are explicitly updating the provider repositories. Often times that is done explicitly after deploying a new provider-project version, so we don't want that to wait for the default minimum release age.

We could consider just excluding the provider-project from the age restriction all together, but this is a safer intermediate step.