### PR TITLE
fix: refresh brace-expansion in provider lockfiles during fleet upgrade

### DIFF
--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -131,6 +131,14 @@ jobs:
           # the `npx projen` on the line above rewrites package.json, so a frozen
           # install would fail with ERR_PNPM_OUTDATED_LOCKFILE. Explicit here too.
           pnpm install --no-frozen-lockfile
+          # Transitive-only lockfile refresh for GHSA-rgw5-rvv9-x895: every provider
+          # repo's committed lockfile still resolves brace-expansion to a flagged
+          # version (<1.1.18 / <2.1.4), and the build's `pnpm audit --audit-level high`
+          # gate fails on it. Neither `pnpm add` above nor projen's upgrade task
+          # touches transitives, so the refresh has to happen here for the upgrade
+          # PRs to be mergeable. No-ops (exit 0) once lockfiles resolve to patched
+          # versions everywhere -- remove it then.
+          pnpm update brace-expansion --depth Infinity
           # MUST be `pnpm run fetch`, never `pnpm fetch`: the latter is a pnpm builtin
           # that fetches from the lockfile, exits 0, and generates no bindings -- the
           # workflow would then find no diff and report success having done nothing.


### PR DESCRIPTION
## Problem

The `pnpm audit --audit-level high` gate in every provider repo's build now fails on **GHSA-rgw5-rvv9-x895** (brace-expansion DoS, flagged <1.1.18 / <2.1.4) — the advisory landed after the last fleet-wide lockfile refresh, so all committed `pnpm-lock.yaml` files resolve to flagged versions. Any PR this workflow creates is unmergeable until each repo's lockfile is refreshed.

Observed on the provider-project **0.9.6 canary** (cdktn-io/cdktn-provider-snowflake): the regen PR #47 and the `upgrade-main` PR #48 both failed audit; #48 only landed after a manual lockfile-only push of brace-expansion 1.1.18 / 2.1.4 — after which the forced Go release succeeded end-to-end (`snowflake/v17.2.0` published, first successful Go publish since the pnpm migration).

## Fix

Add `pnpm update brace-expansion --depth Infinity` to the `Upgrade provider project` step, after the non-frozen install. Neither `pnpm add -D @cdktn/provider-project@latest` nor projen's upgrade task touches transitives, so this workflow is the only fleet-wide place to do it.

- Lockfile-scoped bump to the patched 1.1.18 / 2.1.4 — identical in shape to what provider-project#44 shipped for its own lockfile, and verified on snowflake.
- Exits 0 as a no-op where nothing matches (verified with pnpm 10.33.0), so it's safe for repos already refreshed; remove the line once the fleet's lockfiles have all moved past the flagged ranges.

## Rollout note

Merging this triggers deploy → `upgrade-repositories.yml` across the full fleet, so this merge **is** the provider-project 0.9.6 rollout (pnpm Go publish fix + heap ceiling 20480). Snowflake has already taken 0.9.6 and verified the Go publish path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)