### PR TITLE
feat: azurerm v5

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -3,7 +3,7 @@
   "archive": "hashicorp/archive@~> 2.2",
   "aws": "hashicorp/aws@~> 6.0",
   "azuread": "hashicorp/azuread@~> 3.0",
-  "azurerm": "azurerm@~> 4.0",
+  "azurerm": "azurerm@~> 5.0",
   "cloudflare": "cloudflare/cloudflare@~> 5.0",
   "cloudinit": "hashicorp/cloudinit@~> 2.2",
   "databricks": "databricks/databricks@~> 1.0",


### PR DESCRIPTION
Upgrade azurerm provider to version 5.0.

See https://techcommunity.microsoft.com/blog/azuretoolsblog/terraform-azurerm-provider-5-0-now-generally-available/4542085
See https://github.com/hashicorp/terraform-provider-azurerm/releases#release-v5.0.0 
See https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/5.0-upgrade-guide