### PR TITLE
fix: restore the 0.24 fan-out fixes wiped by the upgrade-cdktf force-push

### DIFF
--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -32,11 +32,15 @@ jobs:
         run: |-
           CDKTF_VERSION=$(yarn info cdktn --json | jq -r '.data.version')
           CDKTF_VERSION_MINOR=$(cut -d "." -f 2 <<< "$CDKTF_VERSION")
+          # Pass cdktn's constructs peer range through VERBATIM. It is not
+          # always caret-style: 0.24.0 ships ">=10.6.0 <10.8.0" (constructs
+          # 10.8 disallowed, cdk-terrain#363), and the old caret-stripping +
+          # re-prepending produced the invalid "^>=10.6.0 <10.8.0", which
+          # broke every provider regen at pnpm install.
           CONSTRUCTS_VERSION=$(yarn info cdktn --json | jq -r '.data.peerDependencies.constructs')
-          CONSTRUCTS_VERSION_EXACT=$(cut -d "^" -f 2 <<< "$CONSTRUCTS_VERSION")
           echo "value=$CDKTF_VERSION" >> $GITHUB_OUTPUT
           echo "short=$CDKTF_VERSION_MINOR" >> $GITHUB_OUTPUT
-          echo "constructs=$CONSTRUCTS_VERSION_EXACT" >> $GITHUB_OUTPUT
+          echo "constructs=$CONSTRUCTS_VERSION" >> $GITHUB_OUTPUT
     outputs:
       current_version: ${{ steps.current_version.outputs.value }}
       current_version_minor: ${{ steps.current_version.outputs.short }}
@@ -69,7 +73,7 @@ jobs:
       - name: Do the upgrade
         run: |
           sed -i "s/cdktnVersion: \".*\",/cdktnVersion: \"^$NEW_CDKTF_VERSION\",/" ./projenrc.template.js
-          sed -i "s/constructsVersion: \".*\",/constructsVersion: \"^$CONSTRUCTS_VERSION\",/" ./projenrc.template.js
+          sed -i "s/constructsVersion: \".*\",/constructsVersion: \"$CONSTRUCTS_VERSION\",/" ./projenrc.template.js
         env:
           NEW_CDKTF_VERSION: ${{ needs.check_versions.outputs.latest_version }}
           CONSTRUCTS_VERSION: ${{ needs.check_versions.outputs.constructs }}
@@ -123,7 +127,7 @@ jobs:
         run: |
           yarn add cdktn@^$NEW_CDKTF_VERSION
           yarn add cdktn-cli@^$NEW_CDKTF_VERSION
-          yarn add constructs@^$CONSTRUCTS_VERSION
+          yarn add "constructs@$CONSTRUCTS_VERSION"
         env:
           NEW_CDKTF_VERSION: ${{ needs.check_versions.outputs.latest_version }}
           CONSTRUCTS_VERSION: ${{ needs.check_versions.outputs.constructs }}

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -39,7 +39,9 @@ jobs:
     name: "Upgrade"
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      # 0.24.0 image (cdk-terrain b91823e3d). Ships Terraform 1.15.8 alongside
+      # the 1.6.5 default; the fetch below selects it via TERRAFORM_BINARY_NAME.
+      image: terraconstructs/jsii-terraform@sha256:8a260318e59d1debad735c328581261f2c469584191ec50783dad135837b4127
     strategy:
       fail-fast: false
       matrix: ${{fromJSON(needs.build-provider-matrix.outputs.matrix)}}
@@ -148,6 +150,16 @@ jobs:
         working-directory: ./provider
         env:
           NODE_OPTIONS: "--max-old-space-size=7168"
+          # Terraform only emits the newer protocol data in `providers schema`
+          # output from these versions on: functions >=1.8, ephemeral resources
+          # >=1.10, write-only attributes >=1.11. The image's default
+          # `terraform` symlink is still 1.6.5 (kept so cdk-terrain's CI
+          # matrices, which key off that default, stay untouched), so the fetch
+          # must select the newer binary explicitly. @cdktn/provider-schema
+          # resolves it from this env var; same mechanism cdk-terrain's
+          # examples.yml uses. Without this, `pnpm run fetch` silently
+          # generates bindings with none of the new 0.24 feature surfaces.
+          TERRAFORM_BINARY_NAME: "terraform1.15.8"
 
       - name: Remove workflows projen no longer generates
         # @cdktn/provider-project v0.7.42 folded force-release.yml into

--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -13,7 +13,11 @@ const project = new CdktnProviderProject({
   nodeHeapSizeMb: __NODE_HEAP_MB__,
   terraformProvider: "__PROVIDER__",
   cdktnVersion: "^0.24.0",
-  constructsVersion: "^>=10.6.0 <10.8.0",
+  // cdktn 0.24's constructs peer range verbatim -- NOT caret-style. cdk-terrain
+  // disallows constructs 10.8 until support lands (open-constructs/cdk-terrain#363),
+  // and a caret here would defeat that upper bound. upgrade-cdktf.yml blindly
+  // prepends "^" when it rewrites this line; fixed to pass ranges through as-is.
+  constructsVersion: ">=10.6.0 <10.8.0",
   // engines.node -- the compat floor we publish to CONSUMERS, not a CI knob.
   // projen's own docs: "Most projects should not use this option ... Setting this
   // option has very high impact on the consumers of your package, as package


### PR DESCRIPTION
## What happened

The two fix commits on `auto/upgrade-providers-cdktn-24` (constructs range + TF 1.15.8 selection, canary-verified on random/aws) were **silently wiped before #63 merged**: a re-run of the failed upgrade-cdktf workflow re-executed `peter-evans/create-pull-request`, which force-pushes the branch with exactly its regenerated content. The squash that landed as `f66f42d` therefore carries the mangled `constructsVersion: "^>=10.6.0 <10.8.0"` and lacks the container digest + `TERRAFORM_BINARY_NAME` — and the fleet fan-out from that merge failed on **all 29 providers** at `pnpm install` (cleanly: no provider PRs were created).

## This PR (cherry-picks of the wiped commits)

- `projenrc.template.js`: `constructsVersion: ">=10.6.0 <10.8.0"` — cdktn 0.24's peer range verbatim (constructs 10.8 disallowed, open-constructs/cdk-terrain#363)
- `upgrade-repositories.yml`: container pinned to the 0.24.0 jsii-terraform digest (`8a260318…`, ships TF 1.15.8) + `TERRAFORM_BINARY_NAME: terraform1.15.8` on the fetch step — without it the regen silently produces bindings with none of the new protocol surfaces (functions/ephemeral/write-only/resource-identity need TF ≥1.8/1.10/1.11/1.12; the image default is 1.6.5)
- `upgrade-cdktf.yml`: pass cdktn's constructs peer range through verbatim instead of caret-mangling it (root cause of the bad template value)

## Rollout note

Merging re-triggers deploy → the full fan-out, now with the exact configuration the canary proved (cdktn-io/cdktn-provider-random#47, cdktn-io/cdktn-provider-aws#81, both merged with ephemeral/functions/write-only surfaces present).

Note: upgrade-cdktf's re-run risk is gone — main's template minor now equals latest (0.24), so its gate no longer opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)