### PR TITLE
fix: bootstrap fresh provider repos with node .projenrc.js

### DIFF
--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -128,7 +128,13 @@ jobs:
           # explicit devDependency wins. Bootstrap it; later synths pin the running
           # version themselves.
           pnpm add -D projen@^0.101.20
-          npx projen
+          # MUST be `node .projenrc.js`, not `npx projen`: the bare projen CLI
+          # resolves its "default" task from .projen/tasks.json, which exists in
+          # every established repo but NOT in a freshly created provider repo --
+          # there the CLI dies with "Unable to find projen project" before the
+          # first synth can create it. Running the projenrc directly is exactly
+          # what the default task does anyway, and works in both cases.
+          node .projenrc.js
           # `unset CI` above matters under pnpm: CI=true implies --frozen-lockfile, and
           # the `npx projen` on the line above rewrites package.json, so a frozen
           # install would fail with ERR_PNPM_OUTDATED_LOCKFILE. Explicit here too.


### PR DESCRIPTION
The cfncompat bootstrap ([run 31181239103](https://github.com/cdktn-io/cdktn-repository-manager/actions/runs/31181239103)) failed at `npx projen` with **Unable to find projen project** — the bare projen CLI resolves its `default` task from `.projen/tasks.json`, which every established repo has committed but a freshly created repo lacks until its first synth. Chicken-and-egg: the CLI needs the artifact only synthesis creates.

Reproduced locally (virgin dir + README + generated `.projenrc.js` + `pnpm add` provider-project/projen): `npx projen` fails, `node .projenrc.js` completes the first synth and generates `.projen/tasks.json` + all workflows. It's also literally what the default task executes, so the ~30 established repos behave identically.

This is the last blocker for the cfncompat bootstrap — merging re-runs the fan-out path that creates its bindings PR. Also required for awscc (#54), which bootstraps the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)