### PR TITLE
feat: generate provider repos from cdktn-provider-template

### DIFF
--- a/.github/lib/check-template-seeded.js
+++ b/.github/lib/check-template-seeded.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+const OWNER = "cdktn-io";
+const REPO = "cdktn-provider-template";
+
+// The workflows a newly generated provider repository needs on its base branch
+// for its first pull request to merge unattended. Authoritative list lives in
+// upgrade-repositories.yml's sync-template job; see docs/template-repo.md.
+const REQUIRED_WORKFLOWS = [
+  "pull-request-lint.yml",
+  "auto-approve.yml",
+  "automerge.yml",
+];
+
+const SEED_INSTRUCTIONS =
+  "Run the 'Upgrade Provider Repositories' workflow (.github/workflows/upgrade-repositories.yml, job sync-template) to seed it, then re-run this deploy.";
+
+module.exports = async ({ github, core }) => {
+  let entries;
+
+  try {
+    const { data } = await github.rest.repos.getContent({
+      owner: OWNER,
+      repo: REPO,
+      path: ".github/workflows",
+    });
+    entries = data;
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error;
+    }
+
+    // A 404 here means either the repository does not exist yet, or it exists
+    // but has no workflows directory. Only the first is acceptable: it is the
+    // bootstrap deploy that creates the template repository itself.
+    try {
+      await github.rest.repos.get({ owner: OWNER, repo: REPO });
+    } catch (repoError) {
+      if (repoError.status === 404) {
+        core.info(
+          `${OWNER}/${REPO} does not exist yet; this deploy is expected to create it.`,
+        );
+        return;
+      }
+      throw repoError;
+    }
+
+    core.setFailed(
+      `${OWNER}/${REPO} exists but has no .github/workflows on its default branch, so repositories generated from it could not merge their first pull request. ${SEED_INSTRUCTIONS}`,
+    );
+    return;
+  }
+
+  const present = new Set(
+    (Array.isArray(entries) ? entries : []).map((entry) => entry.name),
+  );
+  const missing = REQUIRED_WORKFLOWS.filter((name) => !present.has(name));
+
+  if (missing.length > 0) {
+    core.setFailed(
+      `${OWNER}/${REPO} is missing required workflow(s) on its default branch: ${missing.join(", ")}. Repositories generated from it could not merge their first pull request. ${SEED_INSTRUCTIONS}`,
+    );
+    return;
+  }
+
+  core.info(`${OWNER}/${REPO} carries all required workflows.`);
+};

--- a/.github/template-repo/README.md
+++ b/.github/template-repo/README.md
@@ -1,0 +1,22 @@
+# cdktn-provider-template
+
+This repository is a [GitHub template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template). Every `cdktn-provider-<name>` repository in the `cdktn-io` organization is generated from it, so that it is born carrying the workflows its first pull request needs in order to merge unattended.
+
+**Do not open pull requests here, and do not edit files on `main` directly.** GitHub Actions are disabled on this repository, so nothing would run on a pull request, and the next sync would silently overwrite any hand edit.
+
+## Contents
+
+- `.github/workflows/pull-request-lint.yml` — provides the required `Validate PR title` status check
+- `.github/workflows/auto-approve.yml` — supplies the required approving review on bot-authored pull requests
+- `.github/workflows/automerge.yml` — merges a pull request once its checks and review are satisfied
+- `README.md` — this file
+
+The three workflow files are synthesized from `@cdktn/provider-project`, exactly as they are in a real provider repository. The `README.md` is hand-authored.
+
+## Where the content comes from
+
+All of it is maintained by [`cdktn-repository-manager`](https://github.com/cdktn-io/cdktn-repository-manager): the `sync-template` job in `.github/workflows/upgrade-repositories.yml` re-synthesizes the workflows and pushes them here whenever the repository fan-out runs. That repository is the source of truth — see [`docs/template-repo.md`](https://github.com/cdktn-io/cdktn-repository-manager/blob/main/docs/template-repo.md) for the full design, and `.github/template-repo/README.md` there for the source of this file.
+
+## What generated repositories keep
+
+A repository generated from this template starts with the files above. Its first pull request — opened by the same fan-out that maintains this repository — replaces this `README.md` with the provider's own generated README and adds the rest of the provider project. The three workflow files are regenerated there from the provider repository's own `@cdktn/provider-project` and `projen` versions, so they never depend on how fresh this template happens to be.

--- a/.github/workflows/deploy-cdktf-stacks.yml
+++ b/.github/workflows/deploy-cdktf-stacks.yml
@@ -35,6 +35,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Check the provider template repository is seeded
+        # New provider repositories are generated from cdktn-provider-template,
+        # so an unseeded template would produce repositories whose first pull
+        # request can never merge. See docs/template-repo.md.
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const {resolve} = require('path')
+            const scriptPath = resolve("./.github/lib/check-template-seeded")
+            const script = require(scriptPath)
+            await script({ github, core })
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -34,6 +34,146 @@ jobs:
           fi
           echo "matrix=$provider" >> $GITHUB_OUTPUT
 
+  sync-template:
+    name: "Sync template repository"
+    runs-on: ubuntu-latest
+    container:
+      image: terraconstructs/jsii-terraform@sha256:8a260318e59d1debad735c328581261f2c469584191ec50783dad135837b4127
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: main
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: cdktn-io
+          repositories: cdktn-provider-template
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout cdktn-provider-template Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: cdktn-io/cdktn-provider-template
+          token: ${{ steps.app-token.outputs.token }}
+          path: template
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: "10.33.0"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: "24"
+
+      - name: Setup Copywrite tool
+        uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3
+
+      - name: Prepare synth scratch directory
+        # create-projen-files.js writes .projenrc.js to $GITHUB_WORKSPACE/provider,
+        # so the scratch project has to live at exactly that path. `pnpm add` needs
+        # a package.json to add to, and the directory starts out empty.
+        run: |
+          mkdir -p provider
+          printf '%s\n' '{"name":"cdktn-provider-template-synth","version":"0.0.0","private":true}' > provider/package.json
+
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        name: Create projen run commands file
+        with:
+          # The template's files are provider-independent, so any provider key
+          # from provider.json yields the same bytes; "null" is used because it
+          # takes every default (no custom runner, no trusted publishing).
+          script: |
+            const {resolve} = require('path')
+            const scriptPath = resolve("./main/.github/lib/create-projen-files")
+            const script = require(scriptPath)
+            script({
+              providerName: "null"
+            })
+
+      - name: Synthesize provider project
+        # Same resolution path as the fan-out above, so the workflows landing in
+        # the template are the ones a real provider repo synthesizes: latest
+        # @cdktn/provider-project, projen bootstrapped past the pnpm API floor,
+        # stub tasks manifest so `npx projen` works in a virgin directory, and
+        # `unset CI` so pnpm does not demand a frozen lockfile.
+        run: |
+          unset CI
+          pnpm add -D @cdktn/provider-project@latest
+          pnpm add -D projen@^0.101.20
+          if [ ! -f .projen/tasks.json ]; then
+            mkdir -p .projen
+            printf '%s\n' '{"tasks":{"default":{"name":"default","description":"Synthesize project files","steps":[{"execArgs":["node",".projenrc.js"]}]}}}' > .projen/tasks.json
+          fi
+          npx projen
+        working-directory: ./provider
+
+      - name: Add headers using Copywrite tool
+        # The provider repos commit these files with copyright headers applied,
+        # so the template has to carry the same bytes.
+        run: copywrite headers
+        working-directory: ./provider
+
+      - name: Copy template content
+        run: |
+          mkdir -p template/.github/workflows
+          for file in pull-request-lint.yml auto-approve.yml automerge.yml; do
+            if [ ! -f "provider/.github/workflows/$file" ]; then
+              echo "::error::$file was not synthesized by @cdktn/provider-project. A repository generated from the template could no longer merge its first pull request unattended. Update the file list in this job and in docs/template-repo.md."
+              exit 1
+            fi
+            # projen writes its outputs read-only (mode 444), so the previously
+            # synced copy has to be removed before it can be overwritten.
+            rm -f "template/.github/workflows/$file"
+            cp "provider/.github/workflows/$file" "template/.github/workflows/$file"
+          done
+          rm -f template/README.md
+          cp main/.github/template-repo/README.md template/README.md
+
+      - name: Check for changes
+        id: git_diff
+        run: |
+          # Use git status, not `git diff`: diff only sees tracked modifications
+          # and deletions, so a run whose only effect is ADDING files goes
+          # undetected. Detection has to agree with what `git add .` commits.
+          [ -z "$(git status --porcelain)" ] || echo "has_changes=true" >> $GITHUB_OUTPUT
+        working-directory: ./template
+
+      - if: steps.git_diff.outputs.has_changes
+        name: Commit and push changes (if changed)
+        # Pushed straight to main: the template repository runs no CI and has no
+        # pull request flow of its own.
+        run: |
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore: sync template content from cdktn-repository-manager"
+          git push origin HEAD:main
+        working-directory: ./template
+
+      - name: Send failures to Slack
+        if: ${{ failure() && !cancelled() }}
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.FAILURE_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            {
+              "provider_name": "template repository sync",
+              "run_url": "https://github.com/cdktn-io/cdktn-repository-manager/actions/runs/${{ github.run_id }}"
+            }
+
   upgrade-provider:
     needs: build-provider-matrix
     name: "Upgrade"

--- a/docs/template-repo.md
+++ b/docs/template-repo.md
@@ -1,0 +1,199 @@
+# The provider template repository
+
+`cdktn-io/cdktn-provider-template` is a GitHub template repository. Every
+`cdktn-provider-<name>` repository is generated from it, so that a brand-new
+provider repository can merge its first pull request without a human touching
+it.
+
+## The bootstrap problem
+
+A provider repository gets its content from the fan-out in
+`.github/workflows/upgrade-repositories.yml`: the job synthesizes the projen
+project and opens a pull request against the new repository's `main`. For that
+pull request to merge unattended, three things must happen inside the new
+repository:
+
+1. the required status check `Validate PR title` must report success —
+   `pull-request-lint.yml`;
+2. an approving review must appear, because branch protection requires one —
+   `auto-approve.yml`;
+3. something must press merge — `automerge.yml`.
+
+All three are `pull_request_target` workflows, and GitHub runs
+`pull_request_target` workflows **from the base branch**, not from the pull
+request's head. On a repository created empty the base branch contains nothing,
+so none of the three exist, so none of them run: the first pull request sits
+there with a missing required check and no approval, forever.
+
+Making these `pull_request` (head-branch) workflows instead would "fix" the
+first pull request and break the security model. A required check that runs the
+head branch's own definition is defined by the pull request's author, who can
+rewrite the workflow that judges it. Required checks and the auto-approval must
+run the base branch's definition — which means the base branch has to have them
+before the first pull request is opened.
+
+Hence: create the repository with those files already on `main`.
+
+## The mechanism
+
+`cdktn-provider-template` is created and owned by this repository like every
+other repository in the organization — `createProviderTemplateRepo` in
+`main.ts`, using the same `GithubRepository` construct. It differs in three
+ways:
+
+- `isTemplate: true`, so GitHub allows generating from it;
+- minimal branch protection (`protectMainMinimal`): deletion and force-push are
+  blocked, but there are no required status checks and no required reviews,
+  because the sync job pushes straight to `main`;
+- GitHub Actions disabled, via `ActionsRepositoryPermissions { enabled: false }`.
+
+Actions are disabled because the files stored there are `pull_request_target`
+workflows intended to run in the repositories generated from the template. The
+template repository is public, holds no credentials, and has nothing to build,
+so those workflows must never execute in it. Disabling Actions is a repository
+setting: it does not affect generate-from-template (a contents copy) or the
+sync job's push (a contents write).
+
+### Every provider main repo is template-born
+
+`fromProviderTemplate: true` is set unconditionally on every
+`cdktn-provider-<name>` repository in the provider loop, which emits
+
+```hcl
+template {
+  owner      = "cdktn-io"
+  repository = "cdktn-provider-template"
+}
+```
+
+on the `github_repository` resource. `template` and `auto_init` are
+creation-time-only inputs — GitHub never reports them back on a read — so
+`lib/repository.ts` sets, unconditionally and on **every** repository the
+construct creates:
+
+```hcl
+lifecycle {
+  ignore_changes = ["template", "auto_init"]
+}
+```
+
+`lifecycle` is a Terraform meta-argument rather than a provider attribute, so
+this produces no plan diff for the ~60 repositories that already exist
+(verified against live state): they were not created from a template, they
+never will be, and Terraform stops comparing the field. The block only has an
+effect at creation time, for repositories Terraform creates fresh.
+
+The consequence is that onboarding a new provider needs no extra configuration
+file and no allowlist: add it to `provider.json` and `sharded-stacks.json`, and
+its repository is template-born automatically. Repositories brought in through
+`pending-imports.json` are equally unaffected, for the same reason.
+
+Upstream issue [integrations/terraform-provider-github#2090][2090] records
+maintainer intent to make setting `template` on a repository that already
+exists stricter. Today it is inert for existing repositories, and
+`ignore_changes` keeps it inert. **Re-check this when upgrading the GitHub
+provider past 6.6.0** — if the provider starts diffing or forcing replacement
+on `template`, the unconditional application above is what has to change.
+
+[2090]: https://github.com/integrations/terraform-provider-github/issues/2090
+
+### `-go` repositories are excluded
+
+The companion `cdktn-provider-<name>-go` repositories are not generated from
+the template. They have no pull request flow at all: release workflows push
+content into them directly, and they run `protectMain: false`. There is nothing
+for the three workflows to gate, so seeding them would only add files that must
+later be removed.
+
+## Content contract
+
+The template holds exactly four files:
+
+| File                                      | Origin                                                              |
+| ----------------------------------------- | ------------------------------------------------------------------- |
+| `.github/workflows/pull-request-lint.yml` | synthesized                                                         |
+| `.github/workflows/auto-approve.yml`      | synthesized                                                         |
+| `.github/workflows/automerge.yml`         | synthesized                                                         |
+| `README.md`                               | hand-authored, `.github/template-repo/README.md` in this repository |
+
+The selection rule is: **a file belongs in the template if and only if (a) it is
+a base-branch workflow required for the first pull request to merge unattended,
+and (b) its content is provider-independent.** Everything else a provider
+repository needs arrives with that first pull request.
+
+A documented exclusion: `auto-close-community-prs.yml` is also a
+`pull_request_target` workflow, and is therefore also missing from a newborn
+repository's base branch — but it fails both halves of the rule. Its close
+comment embeds the upstream provider's URL, so it is provider-shaped, and it is
+not needed for the first pull request, because the fan-out bot that authors
+that pull request is exempt from it. Newborn repositories gain the file minutes
+later, when the first pull request merges.
+
+The three-file list lives in exactly one place, the `sync-template` job. If
+`@cdktn/provider-project` stops emitting one of them — a rename, a merge into
+another workflow — the job fails loudly with the file name rather than pushing
+a silently incomplete template. That failure is the drift alarm; the fix is to
+update the list in the job and the table above.
+
+## Freshness
+
+`sync-template` is a job in `.github/workflows/upgrade-repositories.yml`,
+sibling to `upgrade-provider` and outside its matrix. It therefore rides the
+existing fan-out: same workflow, same triggers, same cadence, same credentials,
+and it runs after `terraform apply` through the usual chain (`deploy.yml` →
+`deploy-cdktf-stacks.yml` → `upgrade`).
+
+The job synthesizes a throwaway provider project through the same resolution
+path the fan-out uses — `.github/lib/create-projen-files.js` against
+`projenrc.template.js`, then `pnpm add -D @cdktn/provider-project@latest` and
+`npx projen` — runs `copywrite headers` over the output so the bytes match what
+provider repositories actually commit, copies the three workflows plus the
+README into the template checkout, and pushes to `main` only if
+`git status --porcelain` reports a change. There is no pull request: Actions
+are disabled on the template, so no check could ever run there.
+
+Version drift between the template and the fleet is self-healing. A newborn
+repository's first pull request re-synthesizes all of its workflows from its
+own resolved `@cdktn/provider-project` and `projen`, so whatever versions
+produced the template's copies stop mattering the moment that pull request
+merges. The only contract that has to hold across versions is the name of the
+required status check, `Validate PR title`, which is also what
+`protectMainChecks` lists in `main.ts`.
+
+## Birth of a provider repository, end to end
+
+1. A provider is added to `provider.json` and `sharded-stacks.json`.
+2. `deploy.yml` → `deploy-cdktf-stacks.yml` runs the `terraform` job. Before
+   applying, the preflight step calls `.github/lib/check-template-seeded.js`
+   and confirms the template carries the three workflows.
+3. Terraform creates `cdktn-provider-<name>` from the template. The repository
+   exists with `main` already containing the three workflows and the template
+   README, plus branch protection requiring `Validate PR title` and one
+   approving review.
+4. The `upgrade` job fans out. `sync-template` refreshes the template;
+   `upgrade-provider` synthesizes the full provider project and opens pull
+   request #1 against the new repository.
+5. In the new repository, `pull-request-lint.yml` reports `Validate PR title`,
+   `auto-approve.yml` approves, `automerge.yml` merges. The merge replaces the
+   template README, adds the rest of the project, and regenerates the three
+   workflows from the repository's own toolchain versions.
+
+## The deploy preflight
+
+`.github/lib/check-template-seeded.js` runs in the `terraform` job of
+`deploy-cdktf-stacks.yml`, using the job's organization-wide app token. It
+lists `.github/workflows` on the template's default branch:
+
+- template missing all three, or any one, of the workflows → the deploy fails
+  with a message naming the missing files and pointing at `sync-template`;
+- template repository does not exist → the check logs and passes.
+
+That last case is the first-ever deploy, the one that creates the template
+repository. On that deploy the template is created empty (an `auto_init`
+README), so any provider repository created in the **same** apply would be
+generated from an empty template and would still be stuck. If a bootstrap
+deploy ever has to create both, run `upgrade-repositories.yml` (which seeds the
+template) after the apply and before relying on the new provider repository's
+first pull request — or re-run the fan-out, which will open a fresh pull
+request once the base branch has the workflows. In steady state the template
+exists and is seeded, and the preflight is the guard that keeps it that way.

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -24,8 +24,25 @@ export interface RepositoryConfig {
   team: ITeam;
   protectMain?: boolean;
   protectMainChecks?: string[];
+  /**
+   * Minimal branch protection: blocks deletion and force-pushes on main, but
+   * requires no status checks and no reviews, so an automated job can push
+   * straight to main. Only consulted when `protectMain` is false.
+   */
+  protectMainMinimal?: boolean;
   webhookUrl: string;
   provider: GithubProvider;
+  /**
+   * Marks this repository as a GitHub template repository.
+   */
+  isTemplate?: boolean;
+  /**
+   * Provisions this repository by generating it from cdktn-provider-template
+   * instead of from an empty initial commit, so it is born with the
+   * base-branch workflows its first pull request needs.
+   * See docs/template-repo.md.
+   */
+  fromProviderTemplate?: boolean;
 }
 
 export class RepositorySetup extends Construct {
@@ -34,7 +51,12 @@ export class RepositorySetup extends Construct {
     name: string,
     config: Pick<
       RepositoryConfig,
-      "team" | "webhookUrl" | "provider" | "protectMain" | "protectMainChecks"
+      | "team"
+      | "webhookUrl"
+      | "provider"
+      | "protectMain"
+      | "protectMainChecks"
+      | "protectMainMinimal"
     > & {
       repository: Repository | DataGithubRepository;
     },
@@ -45,6 +67,7 @@ export class RepositorySetup extends Construct {
       protectMain = false,
       // TODO: Re-add license/cla ?
       protectMainChecks = ["build"], // , "license/cla"],
+      protectMainMinimal = false,
       provider,
       repository,
       team,
@@ -96,6 +119,15 @@ export class RepositorySetup extends Construct {
         ],
         provider,
       });
+    } else if (protectMainMinimal) {
+      new BranchProtection(this, "main-protection", {
+        pattern: "main",
+        repositoryId: repository.name,
+        enforceAdmins: true,
+        allowsDeletions: false,
+        allowsForcePushes: false,
+        provider,
+      });
     }
 
     new TeamRepository(this, "managing-team", {
@@ -143,6 +175,8 @@ export class GithubRepository extends Construct {
       topics = GithubRepository.defaultTopics,
       description = "Repository management for prebuilt CDK Terrain providers",
       provider,
+      isTemplate = false,
+      fromProviderTemplate = false,
     } = config;
     this.provider = provider;
 
@@ -155,6 +189,7 @@ export class GithubRepository extends Construct {
       hasIssues: !name.endsWith("-go"),
       hasWiki: false,
       autoInit: true,
+      isTemplate,
       hasProjects: false,
       deleteBranchOnMerge: true,
       allowAutoMerge: true,
@@ -164,6 +199,22 @@ export class GithubRepository extends Construct {
       vulnerabilityAlerts: !name.endsWith("-go"),
       topics,
       provider,
+      ...(fromProviderTemplate
+        ? {
+            template: {
+              owner: "cdktn-io",
+              repository: "cdktn-provider-template",
+            },
+          }
+        : {}),
+      // Unconditional, on every repo this construct creates. `template` and
+      // `auto_init` are creation-time-only inputs that GitHub never reports
+      // back, so ignoring them keeps `template{}` a plan no-op on repositories
+      // that already exist or are being imported. Upstream
+      // integrations/terraform-provider-github#2090 flags maintainer intent to
+      // make setting `template` on an existing repository stricter -- re-check
+      // this on provider upgrades past 6.6.0. See docs/template-repo.md.
+      lifecycle: { ignoreChanges: ["template", "auto_init"] },
     });
 
     new RepositorySetup(this, "repository-setup", {

--- a/main.ts
+++ b/main.ts
@@ -27,6 +27,7 @@ import { TerraformVariable } from "cdktf";
 import { GithubProvider } from "@cdktf/provider-github/lib/provider";
 import { DataGithubTeam } from "@cdktf/provider-github/lib/data-github-team";
 import { ActionsSecret } from "@cdktf/provider-github/lib/actions-secret";
+import { ActionsRepositoryPermissions } from "@cdktf/provider-github/lib/actions-repository-permissions";
 
 type StackShards = {
   primaryStack: string;
@@ -128,6 +129,7 @@ class CdkTerrainProviderStack extends TerraformStack {
         githubProvider,
         githubTeam,
       );
+      this.createProviderTemplateRepo(slackWebhook, githubProvider, githubTeam);
     }
 
     const providerRepos: GitUrls[] = Object.keys(providers).map((provider) => {
@@ -147,6 +149,7 @@ class CdkTerrainProviderStack extends TerraformStack {
         ],
         webhookUrl: slackWebhook.stringValue,
         provider: githubProvider,
+        fromProviderTemplate: true,
       });
 
       // repo to publish go packages to
@@ -205,6 +208,48 @@ class CdkTerrainProviderStack extends TerraformStack {
 
     new TerraformOutput(this, "templateRepoUrl", {
       value: templateRepository?.resource.htmlUrl,
+    });
+  }
+
+  /**
+   * cdktn-provider-template: the GitHub template repository every
+   * cdktn-provider-<name> repo is generated from. Its content (three
+   * base-branch workflows plus a README) is kept current by
+   * upgrade-repositories.yml's sync-template job, not by Terraform.
+   * See docs/template-repo.md.
+   */
+  private createProviderTemplateRepo(
+    slackWebhook: TerraformVariable,
+    githubProvider: GithubProvider,
+    githubTeam: DataGithubTeam,
+  ) {
+    const templateRepo = new GithubRepository(this, "cdktn-provider-template", {
+      description:
+        "Template repository new cdktn-io provider repositories are generated from.",
+      topics: ["cdktn", "cdk-terrain", "template"],
+      team: githubTeam,
+      webhookUrl: slackWebhook.stringValue,
+      provider: githubProvider,
+      isTemplate: true,
+      // The sync job pushes straight to main, so main carries no required
+      // checks and no required reviews -- only deletion/force-push guards.
+      protectMainMinimal: true,
+    });
+
+    // The workflows stored here are `pull_request_target` workflows meant to
+    // run in the repositories generated FROM this one. This repository is
+    // public, holds no credentials and has nothing to build, so they must
+    // never execute here. Disabling Actions is a repository setting and does
+    // not affect generate-from-template or the sync job's push, both of which
+    // only read and write contents.
+    new ActionsRepositoryPermissions(this, "template-actions-disabled", {
+      repository: templateRepo.resource.name,
+      enabled: false,
+      provider: githubProvider,
+    });
+
+    new TerraformOutput(this, "providerTemplateRepoUrl", {
+      value: templateRepo.resource.htmlUrl,
     });
   }
 


### PR DESCRIPTION
## Summary

Creates the GitHub template repository `cdktn-io/cdktn-provider-template` and generates every `cdktn-provider-<name>` main repo from it, so a newborn provider repository merges its first fan-out PR unattended — with green checks, an approving review, and automerge, from the first commit.

Full design documentation: [`docs/template-repo.md`](../blob/feat/provider-template-repo/docs/template-repo.md) (added by this PR). The PR body below is the condensed version plus the validation evidence.

## Problem

A newborn repo's first fan-out PR needs **three** things only the *base branch* can provide, because all three are `pull_request_target` workflows (GitHub runs those from the base branch, which is empty on an `auto_init` repo):

1. the required status check **`Validate PR title`** (`pull-request-lint.yml`),
2. the **required approving review** (`auto-approve.yml`),
3. the merge itself (`automerge.yml`).

Running these off the PR head instead is not an option: a required check that executes the PR author's own copy of the workflow is author-tamperable. Precedent: `cdktn-provider-cfncompat` PR #1 needed a human admin-merge that bypassed all checks.

## Design

- **`createProviderTemplateRepo`** (`main.ts`, primary `repos` stack): creates `cdktn-provider-template` with `is_template: true`, **Actions disabled** (`github_actions_repository_permissions { enabled = false }` — the stored workflows are meant to run in *generated* repos, never in the template, which is public and holds no credentials), and **minimal branch protection** (`protectMainMinimal`: blocks deletion/force-push, no required checks or reviews, so the sync job can push directly to `main`).
- **`fromProviderTemplate: true` unconditionally on every provider main repo** (never `-go`, which has no PR flow — release workflows push its content directly). This emits `template { owner = "cdktn-io", repository = "cdktn-provider-template" }` on the `github_repository` resource.
- **Fleet-wide, unconditional `lifecycle { ignore_changes = ["template", "auto_init"] }`** on every repo the construct creates. `template`/`auto_init` are creation-time-only inputs GitHub never reports back, so this makes the `template{}` block a **plan no-op on every pre-existing or imported repo** (verified against live state — see below). Consequence: **onboarding a new provider needs no extra config file** — add it to `provider.json` + `sharded-stacks.json` and its repo is template-born automatically. No allowlist, no append-only ceremony.
- Upstream [integrations/terraform-provider-github#2090](https://github.com/integrations/terraform-provider-github/issues/2090) records maintainer intent to make `template`-on-existing-repo stricter in a future provider version. Inert today at the pinned 6.6.0, kept inert by `ignore_changes`; **re-check on provider upgrades past 6.6.0** (noted in code and docs).

## Content contract & freshness

The template holds exactly **4 files**: the 3 workflows above (synthesized) + a hand-authored `README.md` (source: `.github/template-repo/README.md` here; overwritten in generated repos by their PR #1).

Selection rule (documented in `docs/template-repo.md`): a file belongs in the template **iff** it is (a) a base-branch workflow required for PR #1 to merge unattended **and** (b) provider-independent. Documented exclusion: `auto-close-community-prs.yml` is also `pull_request_target` but fails both halves — its close-comment embeds the upstream provider URL, and PR #1's bot author is exempt from it; newborns gain it minutes later when PR #1 merges.

Freshness rides the **existing fleet mechanism** — no bespoke pipeline, no snapshot dir, no separate GH App, no environment secrets:

- New **`sync-template` job in `upgrade-repositories.yml`** (sibling of `upgrade-provider`, outside its matrix): synthesizes a throwaway project through the *same resolution path as the fan-out* (`create-projen-files.js` → `pnpm add -D @cdktn/provider-project@latest` → `npx projen`, as provider `null` — the 3 files are provider-independent, verified byte-identical across providers), runs `copywrite headers`, copies the 3 workflows + README, and **pushes directly to the template's `main`** only on diff. Same triggers, cadence, container, and `GH_APP_*` credentials as the rest of the fleet; on the deploy chain it runs strictly **after** `terraform apply` (`deploy.yml` → `deploy-cdktf-stacks.yml` → `upgrade`).
- The 3-file list lives in **one place** (the sync job) and the job **fails loudly** if `@cdktn/provider-project` stops emitting an expected file — that's the drift alarm for renames.
- Projen/provider-project version drift is self-healing: every newborn's PR #1 re-synthesizes all files from its own resolved versions. The only cross-version contract is the required check name `Validate PR title`.
- **Deploy preflight** (`.github/lib/check-template-seeded.js`, called via `github-script` in the `terraform` job): fails the deploy if the template exists but is missing any of the 3 workflows; passes when the template repo doesn't exist yet (the bootstrap deploy that creates it).

## Validation evidence

All run against this branch at 4e5ac89:

- `yarn build` / `yarn synth` exit 0 (all 5 stacks), `actionlint` exit 0 on both modified workflows.
- **Synthesized shapes** (`cdktf.out/stacks/repos/cdk.tf.json`): `cdktn-provider-template` has `is_template: true`, Actions-permissions `enabled: false`, and branch protection with *no* required checks/reviews/push restrictions; `cdktn-provider-null` carries both the `template{}` block and the `lifecycle` guard; `cdktn-provider-null-go` and `cdktn-repository-manager` carry **no** `template{}`. 27/27 provider main repos have the block; 0 others do.
- **Byte-identity**: the sync sequence was reproduced locally (`@cdktn/provider-project@0.9.8`, `projen@0.101.31`); all 3 emitted workflows are byte-identical to the copies committed in live `cdktn-io/cdktn-provider-null`, and re-synthesizing as `aws` (custom-runner provider) produced identical bytes — empirically provider-independent.
- **`terraform plan` against live S3 state** (`-refresh=false`, real backend via `aws-vault`, terraform 1.15.8):
  - `repos` stack: **all 56 existing `github_repository` resources plan as no-op** despite every provider main repo now carrying `template{}` in config — the `ignore_changes` guard holds against real recorded state. The only creates are the 9 `cdktn-provider-template` resources (repo, branch protection, actions-permissions, webhook, team, dependabot, 3 labels).
  - `repos-official-new`: all 6 existing `github_repository` no-op, zero creates.
  - `custom-constructs` / `repos-partners` / `github-actions-role`: contain no `github_repository` resources.
  - (The local plan also showed `github_actions_secret`/webhook churn — an artifact of dummy local values for CI-held secret variables. This PR's own `diff.yml` run with real secrets is the authoritative zero-change gate.)
- Recorded state cross-check: all 62 existing repos have `is_template: false`, `template: []`, `auto_init: true` in state — the config additions are exact no-ops.

## Rollout

1. **Merge.** Deploy applies: 9 adds (the template repo + its setup), zero changes to existing repos. The same run's `upgrade` chain then executes `sync-template`, seeding the template's `main` with the 4 files.
2. **Verify seeded**: the 3 workflows + README visible on `cdktn-provider-template@main`; preflight goes green for all subsequent deploys.
3. **First consumer: `awscc`** (#54). Once seeded, merging #54 creates `cdktn-provider-awscc` *from the template*; the fan-out opens PR #1, which lint-passes, auto-approves, and automerges with no human — the failure mode `cfncompat` PR #1 demonstrated, removed.

## Operational notes

- Never add a new provider in the **same PR** that first creates the template repo (that one apply runs before the template is seeded; the preflight deliberately passes on repo-absent). Steady state is fully guarded.
- If a manual `upgrade-repositories.yml` dispatch runs before the template repo exists, `sync-template` fails at checkout — loud, harmless, self-explains.
- `copywrite headers` in the sync job is currently a no-op for these 3 files (projen writes them mode 0444 and the live repo copies carry no headers) — kept as insurance for future provider-project output.
- No new GitHub App, no new secrets, no environments: sync uses the same `GH_APP_*` app the fan-out already uses to push workflow files fleet-wide.
