### PR TITLE
fix: keep issues disabled on cdktn-provider-template

### DIFF
--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -37,6 +37,10 @@ export interface RepositoryConfig {
    */
   isTemplate?: boolean;
   /**
+   * Defaults to true for main repos and false for -go repos.
+   */
+  hasIssues?: boolean;
+  /**
    * Provisions this repository by generating it from cdktn-provider-template
    * instead of from an empty initial commit, so it is born with the
    * base-branch workflows its first pull request needs.
@@ -186,7 +190,7 @@ export class GithubRepository extends Construct {
       archiveOnDestroy: true,
       visibility: "public",
       homepageUrl: "https://cdktn.io",
-      hasIssues: !name.endsWith("-go"),
+      hasIssues: config.hasIssues ?? !name.endsWith("-go"),
       hasWiki: false,
       autoInit: true,
       isTemplate,

--- a/main.ts
+++ b/main.ts
@@ -231,6 +231,9 @@ class CdkTerrainProviderStack extends TerraformStack {
       webhookUrl: slackWebhook.stringValue,
       provider: githubProvider,
       isTemplate: true,
+      // Issues are pointless on a repo whose content is generated; problems
+      // belong in cdktn-repository-manager or cdktn-provider-project.
+      hasIssues: false,
       // The sync job pushes straight to main, so main carries no required
       // checks and no required reviews -- only deletion/force-push guards.
       protectMainMinimal: true,


### PR DESCRIPTION
Captures the manual template-repo setting change in IaC: `has_issues` is now overridable per repo and set `false` for `cdktn-provider-template`, so the next deploy doesn't re-enable Issues there.

Releases/Packages sidebar visibility are GitHub UI toggles with no API/provider representation — nothing to capture for those.

Synth verified: `cdktn-provider-template` → `has_issues: false`; provider main repos unchanged (`true`); `-go` repos unchanged (`false`).

**Merge before #54** — otherwise the awscc deploy reverts the manual setting (harmless but annoying).