### PR TITLE
feat: add Azure/azapi provider bindings

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -3,6 +3,7 @@
   "archive": "hashicorp/archive@~> 2.2",
   "aws": "hashicorp/aws@~> 6.0",
   "awscc": "hashicorp/awscc@~> 1.0",
+  "azapi": "Azure/azapi@~> 2.11",
   "azuread": "hashicorp/azuread@~> 3.0",
   "azurerm": "azurerm@~> 5.0",
   "cfncompat": "cdktn-io/cfncompat@~> 0.1",

--- a/sharded-stacks.json
+++ b/sharded-stacks.json
@@ -9,6 +9,7 @@
         "acme",
         "archive",
         "aws",
+        "azapi",
         "azuread",
         "azurerm",
         "cfncompat",


### PR DESCRIPTION
This provider was never added to cdktf, but it has 253M lifetime downloads and 2.8M downloads in the last week. That is far more than many other provider bindings we maintain.

See https://registry.terraform.io/providers/Azure/azapi/latest