### PR TITLE
chore: add yarn to mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,3 +5,4 @@ jq = "latest"
 node = "20" # move to v22+ after node-gyp isue resolved in CDKTF
 opentofu = "latest"
 terraform = "1.13.3"
+yarn = "1.22.22"


### PR DESCRIPTION
While there is an ongoing effort to move everything to pnpm, until that happens yarn should go in mise. We can replace it with pnpm if/when the migration happens.