### PR TITLE
chore: add pnpm to mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,6 @@
+[settings]
+idiomatic_version_file_enable_tools = ["pnpm"]
+
 [tools]
 "aqua:getsops/sops" = "3.11.0"
 gh = "latest"


### PR DESCRIPTION
We migrated from yarn to pnpm in #80 but neglected to add pnpm to mise like we were going to do for yarn in #74.